### PR TITLE
Add static web interface for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ python3 -m threat_intel.ui
 
 Click **Refresh** to retrieve the latest information.
 
+## Web Interface
+
+A small static web version is available in the `web/` directory. It performs the
+same API call in the browser using JavaScript.
+
+Open `web/index.html` locally or host it via GitHub Pages:
+
+1. Commit the contents of `web/` to your repository.
+2. In the repository settings on GitHub, enable **GitHub Pages** and select the
+   branch containing `web/index.html` as the source.
+3. Your page will be served at `https://<user>.github.io/<repo>/`.
+
+Click **Refresh** on the page to fetch the latest data directly from SANS.
+

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Threat Intelligence Platform</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      padding-top: 40px;
+    }
+    #result {
+      margin-top: 20px;
+      font-size: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Threat Intelligence Platform</h1>
+  <p>Click the button below to fetch today's most attacked country from the SANS Internet Storm Center.</p>
+  <button id="refresh">Refresh</button>
+  <div id="result">Click Refresh to fetch data.</div>
+  <script>
+    async function fetchData() {
+      const resultEl = document.getElementById('result');
+      resultEl.textContent = 'Fetching...';
+      try {
+        const resp = await fetch('https://isc.sans.edu/api/country?json');
+        if (!resp.ok) throw new Error('Network response was not ok');
+        const data = await resp.json();
+        const entries = data.filter(e => e.country);
+        if (!entries.length) {
+          resultEl.textContent = 'No data';
+          return;
+        }
+        const top = entries.reduce((prev, current) => current.targets > prev.targets ? current : prev);
+        const country = top.country;
+        const count = parseInt(top.targets, 10);
+        const flag = country.length === 2 ? String.fromCodePoint(...[...country.toUpperCase()].map(c => c.codePointAt(0) + 127397)) : '';
+        resultEl.textContent = `${country} ${flag} - ${count} targets`;
+      } catch (err) {
+        resultEl.textContent = 'Error: ' + err.message;
+      }
+    }
+    document.getElementById('refresh').addEventListener('click', fetchData);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple HTML frontend under `web/`
- document how to host the project via GitHub Pages

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5fdc9cc08323ad73b90c7b1f5020